### PR TITLE
検査文字列にnilが渡った時は処理せずfalseを返す

### DIFF
--- a/mrblib/mrb_ipfilter/path.rb
+++ b/mrblib/mrb_ipfilter/path.rb
@@ -1,6 +1,7 @@
 module IPFilter
   class Path < Base
     def match?(list, v)
+      v = '' if v.nil?
       list.find{ |l|v.include?(l) }
     end
   end

--- a/mrblib/mrb_ipfilter/path.rb
+++ b/mrblib/mrb_ipfilter/path.rb
@@ -1,7 +1,7 @@
 module IPFilter
   class Path < Base
     def match?(list, v)
-      v = '' if v.nil?
+      return false unless v
       list.find{ |l|v.include?(l) }
     end
   end

--- a/mrblib/mrb_ipfilter/user_agent.rb
+++ b/mrblib/mrb_ipfilter/user_agent.rb
@@ -1,7 +1,7 @@
 module IPFilter
   class UserAgent < Base
     def match?(list, v)
-      v = '' if v.nil?
+      return false unless v
       list.find{ |l|v.include?(l) }
     end
   end

--- a/mrblib/mrb_ipfilter/user_agent.rb
+++ b/mrblib/mrb_ipfilter/user_agent.rb
@@ -1,6 +1,7 @@
 module IPFilter
   class UserAgent < Base
     def match?(list, v)
+      v = '' if v.nil?
       list.find{ |l|v.include?(l) }
     end
   end


### PR DESCRIPTION
UserAgentやPATHのpermit?/deny?呼び出し時に、検査対象文字列がnilの場合 `undefined method 'include?' for nil,` が発生するため、空文字に変換する処理を追加。